### PR TITLE
Increase leading and trailing silence defaults

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MESSAGES CONTROL]
-disable=invalid-name, missing-docstring, too-many-instance-attributes, too-few-public-methods, logging-format-interpolation
+disable=invalid-name, missing-docstring, too-many-instance-attributes, too-few-public-methods, logging-format-interpolation, consider-using-with

--- a/amodem/common.py
+++ b/amodem/common.py
@@ -73,16 +73,6 @@ def take(iterable, n):
     return np.array(list(itertools.islice(iterable, n)))
 
 
-def izip(iterables):
-    """ "Python 3" zip re-implementation for Python 2. """
-    iterables = [iter(iterable) for iterable in iterables]
-    try:
-        while True:
-            yield tuple([next(iterable) for iterable in iterables])
-    except StopIteration:
-        pass
-
-
 class Dummy:
     """ Dummy placeholder object for testing and mocking. """
 

--- a/amodem/config.py
+++ b/amodem/config.py
@@ -14,8 +14,8 @@ class Configuration:
     latency = 0.1
 
     # sender config
-    silence_start = 0.25
-    silence_stop = 0.25
+    silence_start = 0.5
+    silence_stop = 0.5
 
     # receiver config
     skip_start = 0.1

--- a/amodem/recv.py
+++ b/amodem/recv.py
@@ -111,7 +111,7 @@ class Receiver:
             bits = self.modem.decode(S, freq_handler)  # list of bit tuples
             streams.append(bits)  # bit stream per frequency
 
-        return common.izip(streams), symbol_list
+        return zip(*streams), symbol_list
 
     def _demodulate(self, sampler, symbols):
         symbol_list = []

--- a/amodem/tests/test_common.py
+++ b/amodem/tests/test_common.py
@@ -48,12 +48,6 @@ def test_dumps_loads():
     assert all(x == y)
 
 
-def test_izip():
-    x = range(10)
-    y = range(-10, 0)
-    assert list(common.izip([x, y])) == list(zip(x, y))
-
-
 def test_configs():
     default = config.Configuration()
     fastest = config.fastest()

--- a/amodem/tests/test_transfer.py
+++ b/amodem/tests/test_transfer.py
@@ -49,13 +49,18 @@ def run(size, chan=None, df=0, success=True, cfg=None):
         assert rx_data == tx_data
 
 
-@pytest.fixture(params=[0, 1, 3, 10, 42, 123])
+@pytest.fixture(params=[0, 1, 3, 10, 16, 17, 42, 123])
 def small_size(request):
     return request.param
 
 
-def test_small(small_size):
-    run(small_size, chan=lambda x: x)
+@pytest.fixture(params=list(config.bitrates.values()))
+def all_configs(request):
+    return request.param
+
+
+def test_small(small_size, all_configs):
+    run(small_size, chan=lambda x: x, cfg=all_configs)
 
 
 def test_flip():


### PR DESCRIPTION
Leading silence should help ignore initial A/D artifacts.
Trailing silence fixes buffering issues (e.g. #49).