### PR TITLE
Replace deprecated `np.bool` to fix NumPy 1.24 compatibility

### DIFF
--- a/amodem/recv.py
+++ b/amodem/recv.py
@@ -81,7 +81,7 @@ class Receiver:
         equalizer_length = equalizer.equalizer_length
         symbols = self.equalizer.demodulator(equalized, equalizer_length)
         sliced = np.array(symbols).round()
-        errors = np.array(sliced - train_symbols, dtype=np.bool)
+        errors = np.array(sliced - train_symbols, dtype=bool)
         error_rate = errors.sum() / errors.size
 
         errors = np.array(symbols - train_symbols)


### PR DESCRIPTION
Replace the deprecated `np.bool` type with `bool`.  According to the documentation, the former "has been an alias of the builtin" "for a long time".  Using these aliases has been deprecated in NumPy 1.20, and they were removed entirely in 1.24.

See:
https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations