### PR TITLE
Feature for device selection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,19 +73,20 @@ For validation, run::
 
     $ export BITRATE=48  # explicitly select high MODEM bit rate (assuming good SNR).
     $ amodem -h
-    usage: amodem [-h] {send,recv} ...
+    usage: amodem [-h] {send,recv,lsdev} ...
 
-    Audio OFDM MODEM: 48.0 kb/s (64-QAM x 8 carriers) Fs=32.0 kHz
+    Audio OFDM MODEM v1.15.4: 48.0 kb/s (64-QAM x 8 carriers) Fs=32.0 kHz
 
     positional arguments:
-      {send,recv}
-        send         modulate binary data into audio signal.
-        recv         demodulate audio signal into binary data.
+    {send,recv,lsdev}
+        send             modulate binary data into audio signal.
+        recv             demodulate audio signal into binary data.
+        lsdev            list all devices. (portaudio only)
 
     optional arguments:
-      -h, --help     show this help message and exit
+    -h, --help         show this help message and exit
 
-On, Windows you may download the `portaudio` library from `MinGW <https://packages.msys2.org/base/mingw-w64-portaudio>`_.
+On Windows you may download the `portaudio` library from `MinGW <https://packages.msys2.org/base/mingw-w64-portaudio>`_.
 Then, you should specify the DLL using the following command-line flag::
 
     -l AUDIO_LIBRARY, --audio-library AUDIO_LIBRARY
@@ -135,6 +136,18 @@ and send me the resulting ``audio.raw`` file for debugging::
     ~/receiver $ arecord --format=S16_LE --channels=1 --rate=32000 audio.raw
 
 You can see a screencast of the `calibration process <https://asciinema.org/a/25065?autoplay=1>`_.
+
+Devices
+-------
+To specify an input/output device other than default, set the following environment variables::
+    ~/sender $ export OUTAUDIODEVICE=2  # Set output device using device id.
+    ~/sender $ export INAUDIODEVICE=2   # Set input device using device id.
+
+To list input/output devices, use the following command ::
+    ~/sender $ amodem lsdev
+
+To see details of a specific i/o device, specify the device id using ``-d`` as shown below::
+    ~/sender $ amodem lsdev -d 2
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -140,13 +140,16 @@ You can see a screencast of the `calibration process <https://asciinema.org/a/25
 Devices
 -------
 To specify an input/output device other than default, set the following environment variables::
+
     ~/sender $ export OUTAUDIODEVICE=2  # Set output device using device id.
     ~/sender $ export INAUDIODEVICE=2   # Set input device using device id.
 
-To list input/output devices, use the following command ::
+To list input/output devices, use the following command::
+
     ~/sender $ amodem lsdev
 
 To see details of a specific i/o device, specify the device id using ``-d`` as shown below::
+
     ~/sender $ amodem lsdev -d 2
 
 Usage

--- a/amodem/__main__.py
+++ b/amodem/__main__.py
@@ -12,6 +12,7 @@ from . import async_reader
 from . import audio
 from . import calib
 from . import main
+from . import lsdev
 from .config import bitrates
 
 
@@ -25,6 +26,8 @@ log = logging.getLogger('__name__')
 bitrate = os.environ.get('BITRATE', 1)
 config = bitrates.get(int(bitrate))
 
+input_device = os.environ.get('INAUDIODEVICE')
+output_device = os.environ.get('OUTAUDIODEVICE')
 
 class Compressor:
     def __init__(self, stream):
@@ -71,10 +74,10 @@ def FileType(mode, interface_factory=None):
         if fname is None:
             assert audio_interface is not None
             if 'r' in mode:
-                s = audio_interface.recorder()
+                s = audio_interface.recorder(int(input_device))
                 return async_reader.AsyncReader(stream=s, bufsize=s.bufsize)
             if 'w' in mode:
-                return audio_interface.player()
+                return audio_interface.player(int(output_device))
 
         if fname == '-':
             if 'r' in mode:
@@ -177,6 +180,24 @@ def create_parser(description, interface_factory):
         g.add_argument('-v', '--verbose', default=0, action='count')
         g.add_argument('-q', '--quiet', default=False, action='store_true')
 
+
+    device_lister = subparsers.add_parser(
+        'lsdev', help='list all devices. (portaudio only)')
+    device_lister.add_argument(
+        '-d', '--device', help='get details of a single device')
+    device_lister.add_argument('-l', '--audio-library', default='libportaudio.so',
+        help='File name of PortAudio shared library.')
+    device_lister.set_defaults(
+        input_type=FileType('rb'),
+        output_type=FileType('wb'),
+        input=None,
+        output=None,
+        verbose=0,
+        quiet=False,
+        calibrate=False,
+        command='lsdev'
+    )
+
     if argcomplete:
         argcomplete.autocomplete(p)
 
@@ -251,7 +272,12 @@ def _main():
         args.src = args.input_type(args.input)
         args.dst = args.output_type(args.output)
         try:
-            if args.calibrate is False:
+            if args.command == 'lsdev':
+                if args.device:
+                    lsdev.getParticularDevice(interface, int(args.device))
+                else:
+                    lsdev.getDevices(interface)
+            elif args.calibrate is False:
                 args.main(config=config, args=args)
             else:
                 args.calib(config=config, args=args)

--- a/amodem/lsdev.py
+++ b/amodem/lsdev.py
@@ -1,0 +1,33 @@
+from ctypes import *
+
+class PADeviceInfo(Structure):
+    _fields_ = [
+        ("structVersion", c_int),
+        ("name", c_char_p),
+        ("hostApi", c_int),
+        ("maxInputChannels", c_int),
+        ("maxOutputChannels", c_int),
+        ("defaultLowInputLatency", c_double),
+        ("defaultLowOutputLatency", c_double),
+        ("defaultHighInputLatency", c_double),
+        ("defaultHighOutputLatency", c_double),
+        ("defaultSampleRate", c_double)
+    ]
+
+def printDeviceDetails(device):
+    contents = device.contents
+    print(str(contents.name, 'ascii'))
+    print(f"Input Channels: {contents.maxInputChannels}")
+    print(f"Output Channels: {contents.maxOutputChannels}")
+    print(f"Default Sample Rate: {contents.defaultSampleRate}")
+
+def getDevices(interface):
+    num_devices = interface.call('GetDeviceCount', restype=c_int)
+    for i in range(num_devices):
+        device_i = interface.call('GetDeviceInfo', i, restype=POINTER(PADeviceInfo))
+        device_str = str(device_i.contents.name, 'ascii')
+        print(f"Device #{i}: {device_str}")
+
+def getParticularDevice(interface, device_id):
+    device = interface.call('GetDeviceInfo', device_id, restype=POINTER(PADeviceInfo))
+    printDeviceDetails(device)


### PR DESCRIPTION
This feature allows for the selection of input/output devices by setting the environment variables `INAUDIODEVICE` and `OUTAUDIODEVICE`. An additional command `lsdev` is added to view available devices. This feature is only available for portaudio API.