### PR TITLE
add *env* to gitignore so project tree stays clean when using a python…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ htmlcov
 /deb_dist
 *.html
 .pytest_cache/
+*env*


### PR DESCRIPTION
all I did was added *env* to the gitignore so the tree will stay clean when using a venv