### PR TITLE
Add missing `build-system` section to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "amodem"
 version = "1.16.0"


### PR DESCRIPTION
Add missing `build-system` section to make the `pyproject.toml` file conform to PEP 517, and use the correct `setuptools.build_meta` backend. This is necessary to make the package build with the more strict packaging tools, e.g. used by Gentoo.

See: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html